### PR TITLE
Restore complex trainer logic

### DIFF
--- a/unified_trainer/entry_trainer.py
+++ b/unified_trainer/entry_trainer.py
@@ -14,31 +14,68 @@ from .helpers import (
     FeatureBuilder,
     split_datasets,
     ts_split,
+    stack_predict,
+    triple_barrier_label,
 )
 
 
-def load_data(path: str, nrows: int | None = None) -> pd.DataFrame:
+def load_raw(path: str, nrows: int | None = None) -> pd.DataFrame:
     raw = next(read_raw_csv(Path(path)))
     if nrows:
         raw = raw.head(nrows)
-    bars = make_bars(raw, freq="10T")
-    df = FeatureBuilder(bars).build()
-    df["target"] = (df["close"].shift(-1) > df["close"]).astype(int)
-    df.dropna(inplace=True)
-    return df
+    return raw
 
 
 def main(config_path: str = "config.yaml", nrows: int | None = None) -> None:
     config = yaml.safe_load(open(config_path))
-    df = load_data(config["raw_tick_path"], nrows=nrows)
-    is_end = df["timestamp"].iloc[int(len(df) * 0.6)]
-    oos1_end = df["timestamp"].iloc[int(len(df) * 0.8)]
-    df_is, df_oos1, df_oos2 = split_datasets(df, is_end, oos1_end)
+    trend_obj = None
+    if Path(config["output_paths"]["longtrend"]).exists():
+        with open(config["output_paths"]["longtrend"], "rb") as f:
+            trend_obj = pickle.load(f)["model"]
 
-    y = df_is.pop("target")
-    X = df_is.drop(columns=["timestamp"])
+    raw = load_raw(config["raw_tick_path"], nrows=nrows)
+    bars_entry = make_bars(raw, freq="10T")
+    is_end = bars_entry["timestamp"].iloc[int(len(bars_entry) * 0.6)]
+    oos1_end = bars_entry["timestamp"].iloc[int(len(bars_entry) * 0.8)]
+
+    trend_ser = None
+    if trend_obj is not None:
+        bars_trend = make_bars(raw, freq="1H")
+        feat_tr = FeatureBuilder(bars_trend).build()
+        p_trend = stack_predict(trend_obj, feat_tr.drop(columns=["timestamp"]))
+        trend_ser = pd.Series(p_trend, index=bars_trend["timestamp"], name="trend_prob_long")
+
+    def build_features(trial: optuna.trial.Trial) -> pd.DataFrame:
+        fb = FeatureBuilder(bars_entry)
+        df_feat = fb.build(
+            lags=(1, trial.suggest_int("lag2", 3, 10), 12, trial.suggest_int("lag4", 20, 30)),
+            vol_wins=(trial.suggest_int("vs", 10, 30), trial.suggest_int("vl", 50, 120)),
+            sma_wins=(trial.suggest_int("sma_f", 10, 30), trial.suggest_int("sma_s", 40, 120)),
+            ema_spans=(trial.suggest_int("ema_f", 5, 20), trial.suggest_int("ema_s", 20, 60)),
+            rsi_win=trial.suggest_int("rsi_w", 10, 30),
+            boll=(trial.suggest_int("boll_w", 15, 40), trial.suggest_float("boll_s", 1.5, 2.5)),
+        )
+        if trend_ser is not None:
+            df_feat["trend_prob_long"] = trend_ser.reindex(df_feat["timestamp"], method="ffill").values
+        df_feat["target"] = triple_barrier_label(
+            df_feat,
+            trial.suggest_int("hor", 5, 24),
+            trial.suggest_float("thr_up", 0.002, 0.01),
+            trial.suggest_float("thr_dn", 0.002, 0.01),
+        )
+        df_feat["target"] = (df_feat["target"] == 1).astype(int)
+        if df_feat["target"].nunique() < 2:
+            df_feat["target"] = (df_feat["close"].shift(-1) > df_feat["close"]).astype(int)
+        df_feat.dropna(inplace=True)
+        return df_feat
 
     def objective(trial: optuna.trial.Trial) -> float:
+        df_feat = build_features(trial)
+        df_is, _, _ = split_datasets(df_feat, is_end, oos1_end)
+        y = df_is.pop("target")
+        X = df_is.drop(columns=["timestamp"])
+        if y.nunique() < 2:
+            y.iloc[-1] = 1 - y.iloc[-1]
         hp = {
             "rf_ne": trial.suggest_int("rf_ne", 100, 300),
             "rf_md": trial.suggest_int("rf_md", 3, 10),
@@ -48,29 +85,18 @@ def main(config_path: str = "config.yaml", nrows: int | None = None) -> None:
         }
         losses = []
         for tr, va in ts_split(X, config["cv"]["n_splits"]):
-            rf = RandomForestClassifier(
-                n_estimators=hp["rf_ne"],
-                max_depth=hp["rf_md"],
-                random_state=config["cv"]["seed"],
-            )
-            gb = GradientBoostingClassifier(
-                n_estimators=hp["gb_ne"], learning_rate=hp["gb_lr"]
-            )
-
+            rf = RandomForestClassifier(n_estimators=hp["rf_ne"], max_depth=hp["rf_md"], random_state=config["cv"]["seed"])
+            gb = GradientBoostingClassifier(n_estimators=hp["gb_ne"], learning_rate=hp["gb_lr"])
             if len(np.unique(y.iloc[tr])) < 2 or len(np.unique(y.iloc[va])) < 2:
                 losses.append(1.0)
                 continue
-
             rf.fit(X.iloc[tr], y.iloc[tr])
             gb.fit(X.iloc[tr], y.iloc[tr])
             stack = np.column_stack([
                 rf.predict_proba(X.iloc[va])[:, 1],
                 gb.predict_proba(X.iloc[va])[:, 1],
             ])
-
-            meta = LogisticRegression(max_iter=1000, C=hp["meta_c"]).fit(
-                stack, y.iloc[va]
-            )
+            meta = LogisticRegression(max_iter=1000, C=hp["meta_c"]).fit(stack, y.iloc[va])
             pred = meta.predict_proba(stack)[:, 1]
             losses.append(log_loss(y.iloc[va], pred))
         return float(np.mean(losses))
@@ -79,27 +105,18 @@ def main(config_path: str = "config.yaml", nrows: int | None = None) -> None:
     study.optimize(objective, n_trials=config["optuna"]["n_trials"])
     best = study.best_trial.params
 
-    df_feat = FeatureBuilder(make_bars(df, freq="10T")).build()
-    df_feat["target"] = (df_feat["close"].shift(-1) > df_feat["close"]).astype(int)
-    df_feat.dropna(inplace=True)
+    df_feat = build_features(study.best_trial)
     df_is, df_oos1, df_oos2 = split_datasets(df_feat, is_end, oos1_end)
     y = df_is.pop("target")
     X = df_is.drop(columns=["timestamp"])
     if y.nunique() < 2:
         y.iloc[-1] = 1 - y.iloc[-1]
 
-    rf = RandomForestClassifier(
-        n_estimators=best["rf_ne"],
-        max_depth=best["rf_md"],
-        random_state=config["cv"]["seed"],
-    )
-    gb = GradientBoostingClassifier(
-        n_estimators=best["gb_ne"], learning_rate=best["gb_lr"]
-    )
+    rf = RandomForestClassifier(n_estimators=best["rf_ne"], max_depth=best["rf_md"], random_state=config["cv"]["seed"])
+    gb = GradientBoostingClassifier(n_estimators=best["gb_ne"], learning_rate=best["gb_lr"])
     rf.fit(X, y)
     gb.fit(X, y)
     stack = np.column_stack([rf.predict_proba(X)[:, 1], gb.predict_proba(X)[:, 1]])
-
     meta = LogisticRegression(max_iter=1000, C=best["meta_c"]).fit(stack, y)
 
     result = {

--- a/unified_trainer/longtrend_trainer.py
+++ b/unified_trainer/longtrend_trainer.py
@@ -14,31 +14,54 @@ from .helpers import (
     FeatureBuilder,
     split_datasets,
     ts_split,
+    triple_barrier_label,
 )
 
 
-def load_data(path: str, nrows: int | None = None) -> pd.DataFrame:
+def load_raw(path: str, nrows: int | None = None) -> pd.DataFrame:
+    """Load the raw tick CSV/Parquet file."""
     raw = next(read_raw_csv(Path(path)))
     if nrows:
         raw = raw.head(nrows)
-    bars = make_bars(raw, freq="1H")
-    df = FeatureBuilder(bars).build()
-    df["target"] = (df["close"].shift(-1) > df["close"]).astype(int)
-    df.dropna(inplace=True)
-    return df
+    return raw
 
 
 def main(config_path: str = "config.yaml", nrows: int | None = None) -> None:
     config = yaml.safe_load(open(config_path))
-    df = load_data(config["raw_tick_path"], nrows=nrows)
-    is_end = df["timestamp"].iloc[int(len(df) * 0.6)]
-    oos1_end = df["timestamp"].iloc[int(len(df) * 0.8)]
-    df_is, df_oos1, df_oos2 = split_datasets(df, is_end, oos1_end)
+    raw = load_raw(config["raw_tick_path"], nrows=nrows)
+    bars = make_bars(raw, freq="1H")
+    is_end = bars["timestamp"].iloc[int(len(bars) * 0.6)]
+    oos1_end = bars["timestamp"].iloc[int(len(bars) * 0.8)]
 
-    y = df_is.pop("target")
-    X = df_is.drop(columns=["timestamp"])
+    def build_features(trial: optuna.trial.Trial) -> pd.DataFrame:
+        fb = FeatureBuilder(bars)
+        df_feat = fb.build(
+            lags=(1, trial.suggest_int("lag2", 3, 10), 12, trial.suggest_int("lag4", 20, 30)),
+            vol_wins=(trial.suggest_int("vs", 10, 30), trial.suggest_int("vl", 50, 120)),
+            sma_wins=(trial.suggest_int("sma_f", 10, 30), trial.suggest_int("sma_s", 40, 120)),
+            ema_spans=(trial.suggest_int("ema_f", 5, 20), trial.suggest_int("ema_s", 20, 60)),
+            rsi_win=trial.suggest_int("rsi_w", 10, 30),
+            boll=(trial.suggest_int("boll_w", 15, 40), trial.suggest_float("boll_s", 1.5, 2.5)),
+        )
+        df_feat["target"] = triple_barrier_label(
+            df_feat,
+            trial.suggest_int("hor", 5, 24),
+            trial.suggest_float("thr_up", 0.002, 0.01),
+            trial.suggest_float("thr_dn", 0.002, 0.01),
+        )
+        df_feat["target"] = (df_feat["target"] == 1).astype(int)
+        if df_feat["target"].nunique() < 2:
+            df_feat["target"] = (df_feat["close"].shift(-1) > df_feat["close"]).astype(int)
+        df_feat.dropna(inplace=True)
+        return df_feat
 
     def objective(trial: optuna.trial.Trial) -> float:
+        df_feat = build_features(trial)
+        df_is, _, _ = split_datasets(df_feat, is_end, oos1_end)
+        y = df_is.pop("target")
+        X = df_is.drop(columns=["timestamp"])
+        if y.nunique() < 2:
+            y.iloc[-1] = 1 - y.iloc[-1]
         hp = {
             "rf_ne": trial.suggest_int("rf_ne", 100, 300),
             "rf_md": trial.suggest_int("rf_md", 3, 10),
@@ -48,29 +71,18 @@ def main(config_path: str = "config.yaml", nrows: int | None = None) -> None:
         }
         losses = []
         for tr, va in ts_split(X, config["cv"]["n_splits"]):
-            rf = RandomForestClassifier(
-                n_estimators=hp["rf_ne"],
-                max_depth=hp["rf_md"],
-                random_state=config["cv"]["seed"],
-            )
-            gb = GradientBoostingClassifier(
-                n_estimators=hp["gb_ne"], learning_rate=hp["gb_lr"]
-            )
-
+            rf = RandomForestClassifier(n_estimators=hp["rf_ne"], max_depth=hp["rf_md"], random_state=config["cv"]["seed"])
+            gb = GradientBoostingClassifier(n_estimators=hp["gb_ne"], learning_rate=hp["gb_lr"])
             if len(np.unique(y.iloc[tr])) < 2 or len(np.unique(y.iloc[va])) < 2:
                 losses.append(1.0)
                 continue
-
             rf.fit(X.iloc[tr], y.iloc[tr])
             gb.fit(X.iloc[tr], y.iloc[tr])
             stack = np.column_stack([
                 rf.predict_proba(X.iloc[va])[:, 1],
                 gb.predict_proba(X.iloc[va])[:, 1],
             ])
-
-            meta = LogisticRegression(max_iter=1000, C=hp["meta_c"]).fit(
-                stack, y.iloc[va]
-            )
+            meta = LogisticRegression(max_iter=1000, C=hp["meta_c"]).fit(stack, y.iloc[va])
             pred = meta.predict_proba(stack)[:, 1]
             losses.append(log_loss(y.iloc[va], pred))
         return float(np.mean(losses))
@@ -79,27 +91,18 @@ def main(config_path: str = "config.yaml", nrows: int | None = None) -> None:
     study.optimize(objective, n_trials=config["optuna"]["n_trials"])
     best = study.best_trial.params
 
-    df_feat = FeatureBuilder(make_bars(df, freq="1H")).build()
-    df_feat["target"] = (df_feat["close"].shift(-1) > df_feat["close"]).astype(int)
-    df_feat.dropna(inplace=True)
+    df_feat = build_features(study.best_trial)
     df_is, df_oos1, df_oos2 = split_datasets(df_feat, is_end, oos1_end)
     y = df_is.pop("target")
     X = df_is.drop(columns=["timestamp"])
     if y.nunique() < 2:
         y.iloc[-1] = 1 - y.iloc[-1]
 
-    rf = RandomForestClassifier(
-        n_estimators=best["rf_ne"],
-        max_depth=best["rf_md"],
-        random_state=config["cv"]["seed"],
-    )
-    gb = GradientBoostingClassifier(
-        n_estimators=best["gb_ne"], learning_rate=best["gb_lr"]
-    )
+    rf = RandomForestClassifier(n_estimators=best["rf_ne"], max_depth=best["rf_md"], random_state=config["cv"]["seed"])
+    gb = GradientBoostingClassifier(n_estimators=best["gb_ne"], learning_rate=best["gb_lr"])
     rf.fit(X, y)
     gb.fit(X, y)
     stack = np.column_stack([rf.predict_proba(X)[:, 1], gb.predict_proba(X)[:, 1]])
-
     meta = LogisticRegression(max_iter=1000, C=best["meta_c"]).fit(stack, y)
 
     result = {


### PR DESCRIPTION
## Summary
- restore advanced functionality in unified trainer modules
- revert entry, exit, and longtrend trainers to use triple-barrier labels and feature tuning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759320211c832e8dc13f17a8a3bb76